### PR TITLE
Bump core version in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     davinci_plan_net_test_kit (0.9.1)
-      inferno_core (>= 0.4.21)
+      inferno_core (>= 0.4.37)
       tls_test_kit (~> 0.2.0)
 
 GEM

--- a/davinci_plan_net_test_kit.gemspec
+++ b/davinci_plan_net_test_kit.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'DaVinci Plan Net Test Kit'
   spec.homepage      = 'https://github.com/inferno-framework/davinci-plan-net-test-kit'
   spec.license       = 'Apache-2.0'
-  spec.add_runtime_dependency 'inferno_core', '>= 0.4.21'
+  spec.add_runtime_dependency 'inferno_core', '>= 0.4.37'
   spec.add_runtime_dependency 'tls_test_kit', '~> 0.2.0'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'


### PR DESCRIPTION
# Summary
Just bumps the core dependency in the gemspec to a version that supports the HL7 wrapper (specifically, 0.4.37, the latest version as of today)