### PR TITLE
Use Inferno Validator Public Functions only

### DIFF
--- a/lib/davinci_plan_net_test_kit/reference_resolution_test.rb
+++ b/lib/davinci_plan_net_test_kit/reference_resolution_test.rb
@@ -164,7 +164,7 @@ module DaVinciPlanNetTestKit
       # Use the DSL's resource_is_valid? method with add_messages_to_runnable: false
       # to validate silently without adding messages to the test output
       resource_is_valid?(
-        resource: resource,
+        resource:,
         profile_url: target_profile_with_version,
         add_messages_to_runnable: false
       )

--- a/lib/davinci_plan_net_test_kit/reference_resolution_test.rb
+++ b/lib/davinci_plan_net_test_kit/reference_resolution_test.rb
@@ -159,22 +159,17 @@ module DaVinciPlanNetTestKit
     def resource_is_valid_with_target_profile?(resource, target_profile)
       return true if target_profile.blank?
 
-      # Only need to know if the resource is valid.
-      # Calling resource_is_valid? causes validation errors to be logged.
       validator = find_validator(:default)
+      target_profile_with_version = target_profile.include?('|') ? target_profile : "#{target_profile}|#{metadata.profile_version}"
 
-      target_profile_with_version =  target_profile.include?('|') ? target_profile : "#{target_profile}|#{metadata.profile_version}"
-
-      validator_response = validator.validate(resource, target_profile_with_version)
-      outcome = validator.operation_outcome_from_hl7_wrapped_response(validator_response)
-
-      message_hashes = outcome.issue&.map { |issue| validator.message_hash_from_issue(issue, resource) } || []
-
-      message_hashes.concat(validator.additional_validation_messages(resource, target_profile_with_version))
-
-      validator.filter_messages(message_hashes)
-
-      message_hashes.none? { |message_hash| message_hash[:type] == 'error' }
+      # Use the validator's resource_is_valid? method with add_messages_to_runnable: false
+      # to validate silently without adding messages to the test output
+      validator.resource_is_valid?(
+        resource,
+        target_profile_with_version,
+        self,
+        add_messages_to_runnable: false
+      )
     end
   end
 end

--- a/lib/davinci_plan_net_test_kit/reference_resolution_test.rb
+++ b/lib/davinci_plan_net_test_kit/reference_resolution_test.rb
@@ -159,15 +159,13 @@ module DaVinciPlanNetTestKit
     def resource_is_valid_with_target_profile?(resource, target_profile)
       return true if target_profile.blank?
 
-      validator = find_validator(:default)
       target_profile_with_version = target_profile.include?('|') ? target_profile : "#{target_profile}|#{metadata.profile_version}"
 
-      # Use the validator's resource_is_valid? method with add_messages_to_runnable: false
+      # Use the DSL's resource_is_valid? method with add_messages_to_runnable: false
       # to validate silently without adding messages to the test output
-      validator.resource_is_valid?(
-        resource,
-        target_profile_with_version,
-        self,
+      resource_is_valid?(
+        resource: resource,
+        profile_url: target_profile_with_version,
         add_messages_to_runnable: false
       )
     end


### PR DESCRIPTION
# Summary
Updated the reference resolution test to use the public validator service functions, rather than calling the private functions directly. Should result in no change in behavior

For proof see the following two screenshots of a validation test performing identically in both production and locally (after changes):



<img width="3807" height="1902" alt="image" src="https://github.com/user-attachments/assets/f3df989b-f4fc-4646-b267-df1880a2fbf7" />


<img width="3808" height="1933" alt="image" src="https://github.com/user-attachments/assets/6f1daeca-0640-4ca7-af7d-7f5f857d02d3" />
