### PR TITLE
ID-107: check types of values returned from resolve_path

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     davinci_plan_net_test_kit (0.13.1)
-      inferno_core (~> 1.1)
+      inferno_core (~> 1.2)
       tls_test_kit (~> 1.0)
 
 GEM
@@ -139,7 +139,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    inferno_core (1.1.0)
+    inferno_core (1.2.0)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)

--- a/davinci_plan_net_test_kit.gemspec
+++ b/davinci_plan_net_test_kit.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'DaVinci Plan Net Test Kit'
   spec.homepage      = 'https://github.com/inferno-framework/davinci-plan-net-test-kit'
   spec.license       = 'Apache-2.0'
-  spec.add_runtime_dependency 'inferno_core', '~> 1.1'
+  spec.add_runtime_dependency 'inferno_core', '~> 1.2'
   spec.add_runtime_dependency 'tls_test_kit', '~> 1.0'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'

--- a/lib/davinci_plan_net_test_kit/reference_resolution_test.rb
+++ b/lib/davinci_plan_net_test_kit/reference_resolution_test.rb
@@ -84,7 +84,7 @@ module DaVinciPlanNetTestKit
           found_one_reference = false
 
           resolve_one_reference = resources.any? do |resource|
-            value_found = resolve_path(resource, path)
+            value_found = resolve_path(resource, path).select { |value| value.is_a?(FHIR::Reference) }
             next if value_found.empty?
 
             found_one_reference = true


### PR DESCRIPTION
# Summary

A recent [update to the fhir navigation logic in inferno-core](https://github.com/inferno-framework/inferno-core/pull/770) improved the ability of the resolve_path function. This resulted in some tests failing with purple errors due to unsafe use of the resolve_path function that didn't check the types of the returned values before accessing their properties. This update ensures that all uses of resolve_path are safe.

# Testing Guidance

No explicit test failure was detected, so this is a preemptive fix. Run the test kit using a standard PDEX Plan Net Reference Server preset (long running) to ensure no purple errors occur, particularly on the "MustSupport References..." tests at the end of each section (some may skip - that's expected)